### PR TITLE
Have bootstrap command load config file changes during execution (issue #13)

### DIFF
--- a/utils/config.go
+++ b/utils/config.go
@@ -14,10 +14,11 @@ import (
 	"reflect"
 	"runtime"
 	"strings"
+	"time"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/codegangsta/cli"
 	"github.com/mitchellh/go-homedir"
+	log "github.com/sirupsen/logrus"
 )
 
 const windowsServerConfigFile = "c:\\cio\\client.xml"
@@ -35,21 +36,22 @@ const nixServerKeyPath = "/etc/cio/client_ssl/private/key.pem"
 
 // Config stores configuration file contents
 type Config struct {
-	XMLName             xml.Name        `xml:"concerto"`
-	APIEndpoint         string          `xml:"server,attr"`
-	LogFile             string          `xml:"log_file,attr"`
-	LogLevel            string          `xml:"log_level,attr"`
-	Certificate         Cert            `xml:"ssl"`
-	BootstrapConfig     BootstrapConfig `xml:"bootstrap"`
-	ConfLocation        string
-	ConfFile            string
-	IsHost              bool
-	ConcertoURL         string
-	BrownfieldToken     string
-	CommandPollingToken string
-	ServerID            string
-	CurrentUserName     string
-	CurrentUserIsAdmin  bool
+	XMLName              xml.Name        `xml:"concerto"`
+	APIEndpoint          string          `xml:"server,attr"`
+	LogFile              string          `xml:"log_file,attr"`
+	LogLevel             string          `xml:"log_level,attr"`
+	Certificate          Cert            `xml:"ssl"`
+	BootstrapConfig      BootstrapConfig `xml:"bootstrap"`
+	ConfLocation         string
+	ConfFile             string
+	confFileLastLoadedAt time.Time
+	IsHost               bool
+	ConcertoURL          string
+	BrownfieldToken      string
+	CommandPollingToken  string
+	ServerID             string
+	CurrentUserName      string
+	CurrentUserIsAdmin   bool
 }
 
 // Cert stores cert files location
@@ -122,6 +124,30 @@ func InitializeConcertoConfig(c *cli.Context) (*Config, error) {
 
 	debugShowConfig()
 	return cachedConfig, nil
+}
+
+// ReloadConcertoConfig checks if the config file was modified and
+// if so, attempts to reload it. It returns the resulting config
+// (updated or not), whether an modification of the file happened,
+// and any errors
+func ReloadConcertoConfig(c *cli.Context) (*Config, bool, error) {
+	fi, err := os.Stat(cachedConfig.ConfFile)
+	if err != nil {
+		log.Warnf("Could not stat config file %q to see if it changed: %v", cachedConfig.ConfFile, err)
+		return cachedConfig, false, err
+	}
+	if fi.ModTime().After(cachedConfig.confFileLastLoadedAt) {
+		log.Infof("Config file %q changed since last reading, reloading configuration...", cachedConfig.ConfFile)
+		oldConfig := cachedConfig
+		cachedConfig = nil
+		_, err = InitializeConcertoConfig(c)
+		if err != nil {
+			log.Warnf("Could not load changes to config file %q: %v", cachedConfig.ConfFile, err)
+			cachedConfig = oldConfig
+		}
+		return cachedConfig, true, err
+	}
+	return cachedConfig, false, nil
 }
 
 func debugShowConfig() {
@@ -217,6 +243,7 @@ func (config *Config) readConcertoConfig(c *cli.Context) error {
 			return err
 		}
 		defer xmlFile.Close()
+		readingTime := time.Now()
 		b, err := ioutil.ReadAll(xmlFile)
 		if err != nil {
 			return fmt.Errorf("configuration File %s couldn't be read", config.ConfFile)
@@ -225,6 +252,7 @@ func (config *Config) readConcertoConfig(c *cli.Context) error {
 		if err = xml.Unmarshal(b, &config); err != nil {
 			return fmt.Errorf("configuration File %s does not have valid XML format", config.ConfFile)
 		}
+		config.confFileLastLoadedAt = readingTime
 
 	} else {
 		log.Debugf("Configuration File %s does not exist. Reading environment variables", config.ConfFile)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
- Config loading stores the time at which the file is read
- Added utils.ReloadConfig method to reload config, that informs not only on the current config, but if it was updated (and if there was an error)
- Refactor bootstrapping command so that the periodical (default) mode detects changes to config and can change to run-once mode. The reloading also affects to the interval, splay and applyAfterIterations parameters.

# Related Issue

Issue #13 

# Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

# How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

# Screenshots (if appropriate)

# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.