### PR TITLE
Bugfix/15 single operational script run

### DIFF
--- a/api/dispatcher/scripts_api.go
+++ b/api/dispatcher/scripts_api.go
@@ -3,9 +3,10 @@ package dispatcher
 import (
 	"encoding/json"
 	"fmt"
-	log "github.com/sirupsen/logrus"
+
 	"github.com/ingrammicro/cio/api/types"
 	"github.com/ingrammicro/cio/utils"
+	log "github.com/sirupsen/logrus"
 )
 
 // DispatcherService manages bootstrapping operations
@@ -44,9 +45,9 @@ func (ds *DispatcherService) GetDispatcherScriptCharacterizationsByType(phase st
 	return scriptCharacterizations, nil
 }
 
-// GetDispatcherScriptCharacterizationsByUUID returns script characterizations list for a given UUID
-func (ds *DispatcherService) GetDispatcherScriptCharacterizationsByUUID(scriptCharacterizationUUID string) (scriptCharacterizations []*types.ScriptCharacterization, err error) {
-	log.Debug("GetDispatcherScriptCharacterizationsByUUID")
+// GetDispatcherScriptCharacterizationByUUID returns script characterizations list for a given UUID
+func (ds *DispatcherService) GetDispatcherScriptCharacterizationByUUID(scriptCharacterizationUUID string) (*types.ScriptCharacterization, error) {
+	log.Debug("GetDispatcherScriptCharacterizationByUUID")
 
 	data, status, err := ds.concertoService.Get(fmt.Sprintf("/blueprint/script_characterizations/%s", scriptCharacterizationUUID))
 	if err != nil {
@@ -56,12 +57,12 @@ func (ds *DispatcherService) GetDispatcherScriptCharacterizationsByUUID(scriptCh
 	if err = utils.CheckStandardStatus(status, data); err != nil {
 		return nil, err
 	}
-
-	if err = json.Unmarshal(data, &scriptCharacterizations); err != nil {
+	var scriptCharacterization types.ScriptCharacterization
+	if err = json.Unmarshal(data, &scriptCharacterization); err != nil {
 		return nil, err
 	}
 
-	return scriptCharacterizations, nil
+	return &scriptCharacterization, nil
 }
 
 // ReportScriptConclusions reports a result

--- a/api/dispatcher/scripts_api_mocked.go
+++ b/api/dispatcher/scripts_api_mocked.go
@@ -3,10 +3,11 @@ package dispatcher
 import (
 	"encoding/json"
 	"fmt"
+	"testing"
+
 	"github.com/ingrammicro/cio/api/types"
 	"github.com/ingrammicro/cio/utils"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 // GetDispatcherScriptCharacterizationsByTypeMocked test mocked function
@@ -110,8 +111,8 @@ func GetDispatcherScriptCharacterizationsByTypeFailJSONMocked(t *testing.T, phas
 	return scOut
 }
 
-// GetDispatcherScriptCharacterizationsByUUIDMocked test mocked function
-func GetDispatcherScriptCharacterizationsByUUIDMocked(t *testing.T, scriptCharacterizationUUID string, scIn []*types.ScriptCharacterization) []*types.ScriptCharacterization {
+// GetDispatcherScriptCharacterizationByUUIDMocked test mocked function
+func GetDispatcherScriptCharacterizationByUUIDMocked(t *testing.T, scriptCharacterizationUUID string, scIn *types.ScriptCharacterization) *types.ScriptCharacterization {
 
 	assert := assert.New(t)
 
@@ -127,15 +128,15 @@ func GetDispatcherScriptCharacterizationsByUUIDMocked(t *testing.T, scriptCharac
 
 	// call service
 	cs.On("Get", fmt.Sprintf("/blueprint/script_characterizations/%s", scriptCharacterizationUUID)).Return(dIn, 200, nil)
-	scOut, err := ds.GetDispatcherScriptCharacterizationsByUUID(scriptCharacterizationUUID)
+	scOut, err := ds.GetDispatcherScriptCharacterizationByUUID(scriptCharacterizationUUID)
 	assert.Nil(err, "Error getting dispatcher")
-	assert.Equal(scIn, scOut, "GetDispatcherScriptCharacterizationsByUUID returned different services")
+	assert.Equal(scIn, scOut, "GetDispatcherScriptCharacterizationByUUID returned different services")
 
 	return scOut
 }
 
-// GetDispatcherScriptCharacterizationsByUUIDFailErrMocked test mocked function
-func GetDispatcherScriptCharacterizationsByUUIDFailErrMocked(t *testing.T, scriptCharacterizationUUID string, scIn []*types.ScriptCharacterization) []*types.ScriptCharacterization {
+// GetDispatcherScriptCharacterizationByUUIDFailErrMocked test mocked function
+func GetDispatcherScriptCharacterizationByUUIDFailErrMocked(t *testing.T, scriptCharacterizationUUID string, scIn *types.ScriptCharacterization) *types.ScriptCharacterization {
 
 	assert := assert.New(t)
 
@@ -151,7 +152,7 @@ func GetDispatcherScriptCharacterizationsByUUIDFailErrMocked(t *testing.T, scrip
 
 	// call service
 	cs.On("Get", fmt.Sprintf("/blueprint/script_characterizations/%s", scriptCharacterizationUUID)).Return(dIn, 200, fmt.Errorf("mocked error"))
-	scOut, err := ds.GetDispatcherScriptCharacterizationsByUUID(scriptCharacterizationUUID)
+	scOut, err := ds.GetDispatcherScriptCharacterizationByUUID(scriptCharacterizationUUID)
 
 	assert.NotNil(err, "We are expecting an error")
 	assert.Nil(scOut, "Expecting nil output")
@@ -160,8 +161,8 @@ func GetDispatcherScriptCharacterizationsByUUIDFailErrMocked(t *testing.T, scrip
 	return scOut
 }
 
-// GetDispatcherScriptCharacterizationsByUUIDFailStatusMocked test mocked function
-func GetDispatcherScriptCharacterizationsByUUIDFailStatusMocked(t *testing.T, scriptCharacterizationUUID string, scIn []*types.ScriptCharacterization) []*types.ScriptCharacterization {
+// GetDispatcherScriptCharacterizationByUUIDFailStatusMocked test mocked function
+func GetDispatcherScriptCharacterizationByUUIDFailStatusMocked(t *testing.T, scriptCharacterizationUUID string, scIn *types.ScriptCharacterization) *types.ScriptCharacterization {
 
 	assert := assert.New(t)
 
@@ -177,7 +178,7 @@ func GetDispatcherScriptCharacterizationsByUUIDFailStatusMocked(t *testing.T, sc
 
 	// call service
 	cs.On("Get", fmt.Sprintf("/blueprint/script_characterizations/%s", scriptCharacterizationUUID)).Return(dIn, 499, nil)
-	scOut, err := ds.GetDispatcherScriptCharacterizationsByUUID(scriptCharacterizationUUID)
+	scOut, err := ds.GetDispatcherScriptCharacterizationByUUID(scriptCharacterizationUUID)
 
 	assert.NotNil(err, "We are expecting an status code error")
 	assert.Nil(scOut, "Expecting nil output")
@@ -186,8 +187,8 @@ func GetDispatcherScriptCharacterizationsByUUIDFailStatusMocked(t *testing.T, sc
 	return scOut
 }
 
-// GetDispatcherScriptCharacterizationsByUUIDFailJSONMocked test mocked function
-func GetDispatcherScriptCharacterizationsByUUIDFailJSONMocked(t *testing.T, scriptCharacterizationUUID string, scIn []*types.ScriptCharacterization) []*types.ScriptCharacterization {
+// GetDispatcherScriptCharacterizationByUUIDFailJSONMocked test mocked function
+func GetDispatcherScriptCharacterizationByUUIDFailJSONMocked(t *testing.T, scriptCharacterizationUUID string, scIn *types.ScriptCharacterization) *types.ScriptCharacterization {
 
 	assert := assert.New(t)
 
@@ -202,7 +203,7 @@ func GetDispatcherScriptCharacterizationsByUUIDFailJSONMocked(t *testing.T, scri
 
 	// call service
 	cs.On("Get", fmt.Sprintf("/blueprint/script_characterizations/%s", scriptCharacterizationUUID)).Return(dIn, 200, nil)
-	scOut, err := ds.GetDispatcherScriptCharacterizationsByUUID(scriptCharacterizationUUID)
+	scOut, err := ds.GetDispatcherScriptCharacterizationByUUID(scriptCharacterizationUUID)
 
 	assert.NotNil(err, "We are expecting a marshalling error")
 	assert.Nil(scOut, "Expecting nil output")

--- a/api/dispatcher/scripts_api_test.go
+++ b/api/dispatcher/scripts_api_test.go
@@ -1,9 +1,10 @@
 package dispatcher
 
 import (
+	"testing"
+
 	"github.com/ingrammicro/cio/testdata"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestNewDispatcherServiceNil(t *testing.T) {
@@ -21,12 +22,12 @@ func TestGetDispatcherScriptCharacterizationsByType(t *testing.T) {
 	GetDispatcherScriptCharacterizationsByTypeFailJSONMocked(t, "boot", dIn)
 }
 
-func TestGetDispatcherScriptCharacterizationsByUUID(t *testing.T) {
+func TestGetDispatcherScriptCharacterizationByUUID(t *testing.T) {
 	dIn := testdata.GetScriptCharacterizationsData()
-	GetDispatcherScriptCharacterizationsByUUIDMocked(t, "fakeUUID1", dIn)
-	GetDispatcherScriptCharacterizationsByUUIDFailErrMocked(t, "fakeUUID1", dIn)
-	GetDispatcherScriptCharacterizationsByUUIDFailStatusMocked(t, "fakeUUID1", dIn)
-	GetDispatcherScriptCharacterizationsByUUIDFailJSONMocked(t, "fakeUUID1", dIn)
+	GetDispatcherScriptCharacterizationByUUIDMocked(t, "fakeUUID1", dIn[0])
+	GetDispatcherScriptCharacterizationByUUIDFailErrMocked(t, "fakeUUID1", dIn[0])
+	GetDispatcherScriptCharacterizationByUUIDFailStatusMocked(t, "fakeUUID1", dIn[0])
+	GetDispatcherScriptCharacterizationByUUIDFailJSONMocked(t, "fakeUUID1", dIn[0])
 }
 
 func TestReportScriptConclusions(t *testing.T) {

--- a/bootstrapping/bootstrapping.go
+++ b/bootstrapping/bootstrapping.go
@@ -193,7 +193,7 @@ func runBootstrapPeriodically(ctx context.Context, c *cli.Context, formatter for
 				lastPolicyfileApplicationErr = applyPolicyfiles(ctx, bootstrappingSvc, blueprintConfig, formatter, thresholdLines)
 				var configUpdated bool
 				config, configUpdated, err = utils.ReloadConcertoConfig(c)
-				if err != nil && configUpdated {
+				if err == nil && configUpdated {
 					if config.BootstrapConfig.RunOnce {
 						if lastPolicyfileApplicationErr != nil {
 							log.Info("Change to run-once mode detected after a failed policyfile application: starting run-once mode (with 3 retries)...")

--- a/dispatcher/script.go
+++ b/dispatcher/script.go
@@ -2,13 +2,14 @@ package dispatcher
 
 import (
 	"fmt"
-	log "github.com/sirupsen/logrus"
+	"io/ioutil"
+	"os"
+
 	"github.com/codegangsta/cli"
 	"github.com/ingrammicro/cio/api/types"
 	"github.com/ingrammicro/cio/cmd"
 	"github.com/ingrammicro/cio/utils"
-	"io/ioutil"
-	"os"
+	log "github.com/sirupsen/logrus"
 )
 
 func cmdBoot(c *cli.Context) error {
@@ -35,7 +36,9 @@ func execute(c *cli.Context, phase string, scriptCharacterizationUUID string) {
 	if scriptCharacterizationUUID == "" {
 		scriptChars, err = dispatcherSvc.GetDispatcherScriptCharacterizationsByType(phase)
 	} else {
-		scriptChars, err = dispatcherSvc.GetDispatcherScriptCharacterizationsByUUID(scriptCharacterizationUUID)
+		var scriptChar *types.ScriptCharacterization
+		scriptChar, err = dispatcherSvc.GetDispatcherScriptCharacterizationByUUID(scriptCharacterizationUUID)
+		scriptChars = []*types.ScriptCharacterization{scriptChar}
 	}
 	if err != nil {
 		formatter.PrintFatal("Couldn't receive Script Characterization data", err)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->
- `cio scripts operational <id>` fixed by having the command parse the server api single script characterization resource as a single script characterization instead of as a list.
- Fixed cio bootstrapping command config reload application

# Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Issue #15 

# Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

# How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually on a develop environment and with tests (for the script characterization-related changes)

# Screenshots (if appropriate)

# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.