### PR TITLE
Add http request timeout plus ReportScriptConclusions retry (IMCO-707)

### DIFF
--- a/utils/webservice.go
+++ b/utils/webservice.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -20,6 +21,7 @@ import (
 const WebServiceConfigurationFailed = "web service configuration failed. No data in configuration"
 const ContentTypeApplicationJson = "application/json"
 const ConfigurationIsIncomplete = "configuration is incomplete"
+const HttpTimeOut = 30
 
 // ConcertoService defines actions to be performed by web service manager
 type ConcertoService interface {
@@ -80,6 +82,7 @@ func NewHTTPConcertoService(config *Config) (hcs *HTTPConcertoservice, err error
 				Certificates: []tls.Certificate{cert},
 			},
 		},
+		Timeout: time.Second * time.Duration(HttpTimeOut),
 	}
 	return hcs, nil
 }
@@ -106,6 +109,7 @@ func NewHTTPConcertoServiceWithBrownfieldToken(config *Config) (hcs *HTTPConcert
 				InsecureSkipVerify: true,
 			},
 		},
+		Timeout: time.Second * time.Duration(HttpTimeOut),
 	}
 	return hcs, nil
 }
@@ -132,6 +136,7 @@ func NewHTTPConcertoServiceWithCommandPolling(config *Config) (hcs *HTTPConcerto
 				InsecureSkipVerify: true,
 			},
 		},
+		Timeout: time.Second * time.Duration(HttpTimeOut),
 	}
 	return hcs, nil
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Add a 30 sec timeout to the http.Client.
Retry ReportScriptConclusions call up to 5 times in case an error occurs

# Related Issue

IMCO-707

# Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

# How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

# Screenshots (if appropriate)

# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.