### PR TITLE
Fix ATTACHMENT_DIR env var on windows (issue #93)

### DIFF
--- a/dispatcher/script.go
+++ b/dispatcher/script.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/ingrammicro/cio/api/dispatcher"
@@ -103,7 +104,7 @@ func execute(c *cli.Context, phase string, scriptCharacterizationUUID string) {
 		}
 		defer os.RemoveAll(path)
 
-		if err = os.Setenv("ATTACHMENT_DIR", fmt.Sprintf("%s/%s", path, "attachments")); err != nil {
+		if err = os.Setenv("ATTACHMENT_DIR", filepath.Join(path, "attachments")); err != nil {
 			formatter.PrintFatal("Couldn't set attachments directory as environment variable", err)
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->
Use filepath.Join to join paths with the right separator on Windows

# Related Issue
#93 

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

# Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

# How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

# Screenshots (if appropriate)

# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.